### PR TITLE
Common rules

### DIFF
--- a/fp.js
+++ b/fp.js
@@ -21,9 +21,9 @@ module.exports = {
     "fp/no-unused-expression": "warn",
     "fp/no-valueof-field": "error",
     "no-new-object": "warn",
-    "no-magic-numbers": [2, {  "ignore": [0,1] }],
-    "no-unused-expressions": 2, // disallow usage of expressions in statement position
-    "no-lonely-if": 2, // disallow if as the only statement in an else block
-    "sort-keys": [1, "asc", {"caseSensitive": true, "natural": false}],
+    "no-magic-numbers": ["error", {  "ignore": [0,1] }],
+    "no-unused-expressions": "error", // disallow usage of expressions in statement position
+    "no-lonely-if": "error", // disallow if as the only statement in an else block
+    "sort-keys": ["warn", "asc", {"caseSensitive": true, "natural": false}],
   },
 }

--- a/index.js
+++ b/index.js
@@ -9,9 +9,18 @@ module.exports = {
   "parserOptions": {
     "ecmaVersion": 2021
   },
-  "plugins": ["mocha","promise","security-node"],
+  "plugins": [
+    "mocha",
+    "promise",
+    "security-node"
+  ],
 
-  "extends": ["eslint:recommended","plugin:mocha/recommended","plugin:promise/recommended","plugin:security-node/recommended"],
+  "extends": [
+    "eslint:recommended",
+    "plugin:mocha/recommended",
+    "plugin:promise/recommended",
+    "plugin:security-node/recommended"
+  ],
 
   "rules": {
 
@@ -19,163 +28,163 @@ module.exports = {
     // Default rules are split up based on sections found on the eslint rules page.
     // Rules should be sorted alphabetically inside each section.
 
-    "strict": 0,
+    "strict": "off",
 
     // Possible Errors
-    "comma-dangle": [2, "always-multiline"], // disallow or enforce trailing commas
-    "no-cond-assign": 2, // disallow assignment in conditional expressions
-    "no-console": 0, // disallow use of console in the node environment
-    "no-constant-condition": 2, // disallow use of constant expressions in conditions
-    "no-control-regex": 2, // disallow control characters in regular expressions
-    "no-debugger": 1, // disallow use of debugger
-    "no-dupe-args": 2, // disallow duplicate arguments in functions
-    "no-dupe-keys": 2, // disallow duplicate keys when creating object literals
-    "no-duplicate-case": 2, // disallow a duplicate case label
-    "no-empty": 2, // disallow empty statements
-    "no-empty-character-class": 0, // disallow the use of empty character classes in regular expressions
-    "no-ex-assign": 2, // disallow assigning to the exception in a catch block
-    "no-extra-boolean-cast": 2, // disallow double-negation boolean casts in a boolean context
-    "no-extra-parens": [2, "functions"], // disallow unnecessary parentheses
-    "no-extra-semi": 2, // disallow unnecessary semicolons
-    "no-func-assign": 2, // disallow overwriting functions written as function declarations
-    "no-inner-declarations": [2, "functions"], // disallow function or variable declarations in nested blocks
-    "no-invalid-regexp": 0, // disallow invalid regular expression strings in the RegExp constructor
-    "no-irregular-whitespace": 0, // disallow irregular whitespace outside of strings and comments
-    "no-negated-in-lhs": 0, // disallow negation of the left operand of an in expression
-    "no-obj-calls": 2, // disallow the use of object properties of the global object (Math and JSON) as functions
-    "no-regex-spaces": 0, // disallow multiple spaces in a regular expression literal
-    "no-sparse-arrays": 1, // disallow sparse arrays
-    "no-undef": 2, // disallow use of undeclared variables unless mentioned in a /*global */ block
-    "no-unexpected-multiline": 2, // avoid code that looks like two expressions but is actually one
-    "no-unreachable": 2, // disallow unreachable statements after a return, throw, continue, or break statement
-    "no-unused-vars": 2, // disallow declaration of variables that are not used in the code
-    "no-use-before-define": [2, "nofunc"], // disallow use of variables before they are defined
-    "use-isnan": 2, // disallow comparisons with the value NaN
-    "valid-jsdoc": [1, {
+    "comma-dangle": ["error", "always-multiline"], // disallow or enforce trailing commas
+    "no-cond-assign": "error", // disallow assignment in conditional expressions
+    "no-console": "off", // disallow use of console in the node environment
+    "no-constant-condition": "error", // disallow use of constant expressions in conditions
+    "no-control-regex": "error", // disallow control characters in regular expressions
+    "no-debugger": "warn", // disallow use of debugger
+    "no-dupe-args": "error", // disallow duplicate arguments in functions
+    "no-dupe-keys": "error", // disallow duplicate keys when creating object literals
+    "no-duplicate-case": "error", // disallow a duplicate case label
+    "no-empty": "error", // disallow empty statements
+    "no-empty-character-class": "off", // disallow the use of empty character classes in regular expressions
+    "no-ex-assign": "error", // disallow assigning to the exception in a catch block
+    "no-extra-boolean-cast": "error", // disallow double-negation boolean casts in a boolean context
+    "no-extra-parens": ["error", "functions"], // disallow unnecessary parentheses
+    "no-extra-semi": "error", // disallow unnecessary semicolons
+    "no-func-assign": "error", // disallow overwriting functions written as function declarations
+    "no-inner-declarations": ["error", "functions"], // disallow function or variable declarations in nested blocks
+    "no-invalid-regexp": "off", // disallow invalid regular expression strings in the RegExp constructor
+    "no-irregular-whitespace": "off", // disallow irregular whitespace outside of strings and comments
+    "no-negated-in-lhs": "off", // disallow negation of the left operand of an in expression
+    "no-obj-calls": "error", // disallow the use of object properties of the global object (Math and JSON) as functions
+    "no-regex-spaces": "off", // disallow multiple spaces in a regular expression literal
+    "no-sparse-arrays": "warn", // disallow sparse arrays
+    "no-undef": "error", // disallow use of undeclared variables unless mentioned in a /*global */ block
+    "no-unexpected-multiline": "error", // avoid code that looks like two expressions but is actually one
+    "no-unreachable": "error", // disallow unreachable statements after a return, throw, continue, or break statement
+    "no-unused-vars": "error", // disallow declaration of variables that are not used in the code
+    "no-use-before-define": ["error", "nofunc"], // disallow use of variables before they are defined
+    "use-isnan": "error", // disallow comparisons with the value NaN
+    "valid-jsdoc": ["warn", {
       "requireReturn": false,
       "requireReturnDescription": false,
       "requireReturnType": false
     }], // Ensure JSDoc comments are valid
-    "valid-typeof": 2, // Ensure that the results of typeof are compared against a valid string
+    "valid-typeof": "error", // Ensure that the results of typeof are compared against a valid string
 
     // Best Practices
-    "accessor-pairs": 2, // Enforces getter/setter pairs in objects
-    "block-scoped-var": 0, // treat var statements as if they were block scoped
-    "complexity": [2, 10], // specify the maximum cyclomatic complexity allowed in a program
-    "consistent-return": 2, // require return statements to either always or never specify values
-    "curly": 0, // specify curly brace conventions for all control statements
-    "default-case": 2, // require default case in switch statements
-    "dot-location": 0, // enforces consistent newlines before or after dots
-    "dot-notation": 2, // encourages use of dot notation whenever possible
-    "eqeqeq": [2, "smart"], // require the use of === and !==
-    "guard-for-in": 0, // make sure for-in loops have an if statement
-    "no-alert": 1, // disallow the use of alert, confirm, and prompt
-    "no-caller": 1, // disallow use of arguments.caller or arguments.callee
-    "no-case-declarations": 0, // disallow lexical declarations in case clauses
-    "no-div-regex": 0, // disallow division operators explicitly at beginning of regular expression
-    "no-else-return": 2, // disallow else after a return in an if
-    "no-empty-label": 0, // disallow use of labels for anything other than loops and switches
-    "no-empty-pattern": 0, // disallow use of empty destructuring patterns
-    "no-eq-null": 0, // disallow comparisons to null without a type-checking operator
-    "no-eval": 2, // disallow use of eval()
-    "no-extend-native": 2, // disallow adding to native types
-    "no-extra-bind": 2, // disallow unnecessary function binding
-    "no-fallthrough": 2, // disallow fallthrough of case statements
-    "no-floating-decimal": 0, // disallow the use of leading or trailing decimal points in numeric literals
-    "no-implicit-coercion": 0, // disallow the type conversions with shorter notations
-    "no-implied-eval": 2, // disallow use of eval()-like methods
-    "no-invalid-this": 0, // disallow this keywords outside of classes or class-like objects
-    "no-iterator": 1, // disallow usage of __iterator__ property
-    "no-labels": 0, // disallow use of labeled statements
-    "no-lone-blocks": 2, // disallow unnecessary nested blocks
-    "no-loop-func": 2, // disallow creation of functions within loops
-    "no-magic-numbers": 0, // isallow the use of magic numbers
-    "no-multi-spaces": 0, // disallow use of multiple spaces
-    "no-multi-str": 0, // disallow use of multiline strings
-    "no-native-reassign": 2, // disallow reassignments of native objects
-    "no-new": 1, // disallow use of the new operator when not part of an assignment or comparison
-    "no-new-func": 1, // disallow use of new operator for Function object
-    "no-new-wrappers": 1, // disallows creating new instances of String,Number, and Boolean
-    "no-octal": 0, // disallow use of octal literals
-    "no-octal-escape": 0, // disallow use of octal escape sequences in string literals, such as var foo = "Copyright \251";
-    "no-param-reassign": 1, // disallow reassignment of function parameters
-    "no-process-env": 0, // disallow use of process.env
-    "no-proto": 2, // disallow usage of __proto__ property
-    "no-redeclare": 2, // disallow declaring the same variable more than once
-    "no-return-assign": 0, // disallow use of assignment in return statement
-    "no-script-url": 0, // disallow use of javascript: urls.
-    "no-self-compare": 2, // disallow comparisons where both sides are exactly the same
-    "no-sequences": 2, // disallow use of the comma operator
-    "no-throw-literal": 2, // restrict what can be thrown as an exception
-    "no-useless-call": 2, // disallow unnecessary .call() and .apply()
-    "no-useless-concat": 1, // disallow unnecessary concatenation of literals or template literals
-    "no-void": 1, // disallow use of the void operator
-    "no-warning-comments": 0, // disallow usage of configurable warning terms in comments - e.g. TODO or FIXME
-    "no-with": 2, // disallow use of the with statement
-    "radix": 2, // require use of the second argument for parseInt()
-    "vars-on-top": 0, // require declaration of all vars at the top of their containing scope
-    "wrap-iife": 0, // require immediate function invocation to be wrapped in parentheses
-    "yoda": 0, // require or disallow Yoda conditions
+    "accessor-pairs": "error", // Enforces getter/setter pairs in objects
+    "block-scoped-var": "off", // treat var statements as if they were block scoped
+    "complexity": ["error", 10], // specify the maximum cyclomatic complexity allowed in a program
+    "consistent-return": "error", // require return statements to either always or never specify values
+    "curly": "off", // specify curly brace conventions for all control statements
+    "default-case": "error", // require default case in switch statements
+    "dot-location": "off", // enforces consistent newlines before or after dots
+    "dot-notation": "error", // encourages use of dot notation whenever possible
+    "eqeqeq": ["error", "smart"], // require the use of === and !==
+    "guard-for-in": "off", // make sure for-in loops have an if statement
+    "no-alert": "warn", // disallow the use of alert, confirm, and prompt
+    "no-caller": "warn", // disallow use of arguments.caller or arguments.callee
+    "no-case-declarations": "off", // disallow lexical declarations in case clauses
+    "no-div-regex": "off", // disallow division operators explicitly at beginning of regular expression
+    "no-else-return": "error", // disallow else after a return in an if
+    "no-empty-label": "off", // disallow use of labels for anything other than loops and switches
+    "no-empty-pattern": "off", // disallow use of empty destructuring patterns
+    "no-eq-null": "off", // disallow comparisons to null without a type-checking operator
+    "no-eval": "error", // disallow use of eval()
+    "no-extend-native": "error", // disallow adding to native types
+    "no-extra-bind": "error", // disallow unnecessary function binding
+    "no-fallthrough": "error", // disallow fallthrough of case statements
+    "no-floating-decimal": "off", // disallow the use of leading or trailing decimal points in numeric literals
+    "no-implicit-coercion": "off", // disallow the type conversions with shorter notations
+    "no-implied-eval": "error", // disallow use of eval()-like methods
+    "no-invalid-this": "off", // disallow this keywords outside of classes or class-like objects
+    "no-iterator": "warn", // disallow usage of __iterator__ property
+    "no-labels": "off", // disallow use of labeled statements
+    "no-lone-blocks": "error", // disallow unnecessary nested blocks
+    "no-loop-func": "error", // disallow creation of functions within loops
+    "no-magic-numbers": "off", // isallow the use of magic numbers
+    "no-multi-spaces": "off", // disallow use of multiple spaces
+    "no-multi-str": "off", // disallow use of multiline strings
+    "no-native-reassign": "error", // disallow reassignments of native objects
+    "no-new": "warn", // disallow use of the new operator when not part of an assignment or comparison
+    "no-new-func": "warn", // disallow use of new operator for Function object
+    "no-new-wrappers": "warn", // disallows creating new instances of String,Number, and Boolean
+    "no-octal": "off", // disallow use of octal literals
+    "no-octal-escape": "off", // disallow use of octal escape sequences in string literals, such as var foo = "Copyright \251";
+    "no-param-reassign": "warn", // disallow reassignment of function parameters
+    "no-process-env": "off", // disallow use of process.env
+    "no-proto": "error", // disallow usage of __proto__ property
+    "no-redeclare": "error", // disallow declaring the same variable more than once
+    "no-return-assign": "off", // disallow use of assignment in return statement
+    "no-script-url": "off", // disallow use of javascript: urls.
+    "no-self-compare": "error", // disallow comparisons where both sides are exactly the same
+    "no-sequences": "error", // disallow use of the comma operator
+    "no-throw-literal": "error", // restrict what can be thrown as an exception
+    "no-useless-call": "error", // disallow unnecessary .call() and .apply()
+    "no-useless-concat": "warn", // disallow unnecessary concatenation of literals or template literals
+    "no-void": "warn", // disallow use of the void operator
+    "no-warning-comments": "off", // disallow usage of configurable warning terms in comments - e.g. TODO or FIXME
+    "no-with": "error", // disallow use of the with statement
+    "radix": "error", // require use of the second argument for parseInt()
+    "vars-on-top": "off", // require declaration of all vars at the top of their containing scope
+    "wrap-iife": "off", // require immediate function invocation to be wrapped in parentheses
+    "yoda": "off", // require or disallow Yoda conditions
 
     // Stylistic Issues
-    "array-bracket-spacing": [2, "never"], // enforce spacing inside array brackets
-    "block-spacing": 0, // disallow or enforce spaces inside of single line blocks
-    "brace-style": [2, "1tbs"], // enforce one true brace style
-    "camelcase": 2, // require camel case names
-    "comma-spacing": 2, // enforce spacing before and after comma
-    "comma-style": 2, // enforce one true comma style
-    "computed-property-spacing": 0, // require or disallow padding inside computed properties
-    "consistent-this": 0, // enforce consistent naming when capturing the current execution context
-    "eol-last": 2, // enforce newline at the end of file, with no multiple empty lines
-    "func-names": 0, // require function expressions to have a name
-    "func-style": [2, "declaration",  {"allowArrowFunctions": true}], // enforce use of function declarations or expressions
-    "id-length": 0, // this option enforces minimum and maximum identifier lengths (variable names, property names etc.)
-    "id-match": 0, // require identifiers to match the provided regular expression
-    "indent": [2, 2], // specify tab or space width for your code
-    "jsx-quotes": [2, "prefer-double"], // specify whether double or single quotes should be used in JSX attributes
-    "key-spacing": 2, // enforce spacing between keys and values in object literal properties
-    "keyword-spacing": 2, // require a space after certain keywords
-    "linebreak-style": [2, "unix"], // disallow mixed 'LF' and 'CRLF' as linebreaks
-    "lines-around-comment": 2, // enforce empty lines around comments
-    "max-depth": 0, // specify the maximum depth that blocks can be nested
-    "max-len": 0, // specify the maximum length of a line in your program
-    "max-nested-callbacks": [2, 3], // specify the maximum depth callbacks can be nested
-    "max-params": [1, {max:5}], // limits the number of parameters that can be used in the function declaration.
-    "max-statements": [1, {max:15}], // specify the maximum number of statement allowed in a function
-    "new-cap": [2, { "capIsNew": false }], // require a capital letter for constructors
-    "new-parens": 2, // disallow the omission of parentheses when invoking a constructor with no arguments
-    "newline-after-var": 0, // require or disallow an empty newline after variable declarations
-    "no-array-constructor": 1, // disallow use of the Array constructor
-    "no-bitwise": 0, // disallow use of bitwise operators
-    "no-continue": 0, // disallow use of the continue statement
-    "no-inline-comments": 0, // disallow comments inline after code
-    "no-lonely-if": 0, // disallow if as the only statement in an else block
-    "no-mixed-spaces-and-tabs": 2, // disallow mixed spaces and tabs for indentation
-    "no-multiple-empty-lines": [1, { "max": 3 }], // disallow multiple empty lines
-    "no-negated-condition": 0, // disallow negated conditions
-    "no-nested-ternary": 2, // disallow nested ternary expressions
-    "no-new-object": 1, // disallow the use of the Object constructor
-    "no-plusplus": 1, // disallow use of unary operators, ++ and --
-    "no-restricted-syntax": 0, // disallow use of certain syntax in code
-    "no-spaced-func": 0, // disallow space between function identifier and application
-    "no-ternary": 0, // disallow the use of ternary operators
-    "no-trailing-spaces": 2, // disallow trailing whitespace at the end of lines
-    "no-underscore-dangle": 0, // disallow dangling underscores in identifiers
-    "no-unneeded-ternary": 2, // disallow the use of ternary operators when a simpler alternative exists
-    "no-useless-escape": 0,
-    "object-curly-spacing": [2, "never"], // require or disallow padding inside curly braces
-    "one-var": 0, // require or disallow one variable declaration per function
-    "operator-assignment": 0, // require assignment operator shorthand where possible or prohibit it entirely
-    "operator-linebreak": 0, // enforce operators to be placed before or after line breaks
-    "padded-blocks": 0, // enforce padding within blocks
-    "quote-props": 0, // require quotes around object literal property names
-    "quotes": [2, "double"], // specify whether backticks, double or single quotes should be used
-    "require-jsdoc": 0, // Require JSDoc comment
-    "semi": [2, "never"], // require or disallow use of semicolons instead of ASI
-    "semi-spacing": 0, // enforce spacing before and after semicolons
-    "sort-vars": 2, // sort variables within the same declaration block
-    "sort-keys": [0, "asc", {"caseSensitive": true, "natural": false}],
-    "space-before-blocks": 2, // space-before-blocks
+    "array-bracket-spacing": ["error", "never"], // enforce spacing inside array brackets
+    "block-spacing": "off", // disallow or enforce spaces inside of single line blocks
+    "brace-style": ["error", "1tbs"], // enforce one true brace style
+    "camelcase": "error", // require camel case names
+    "comma-spacing": "error", // enforce spacing before and after comma
+    "comma-style": "error", // enforce one true comma style
+    "computed-property-spacing": "off", // require or disallow padding inside computed properties
+    "consistent-this": "off", // enforce consistent naming when capturing the current execution context
+    "eol-last": "error", // enforce newline at the end of file, with no multiple empty lines
+    "func-names": "off", // require function expressions to have a name
+    "func-style": ["error", "declaration",  {"allowArrowFunctions": true}], // enforce use of function declarations or expressions
+    "id-length": "off", // this option enforces minimum and maximum identifier lengths (variable names, property names etc.)
+    "id-match": "off", // require identifiers to match the provided regular expression
+    "indent": ["error", 2], // specify tab or space width for your code
+    "jsx-quotes": ["error", "prefer-double"], // specify whether double or single quotes should be used in JSX attributes
+    "key-spacing": "error", // enforce spacing between keys and values in object literal properties
+    "keyword-spacing": "error", // require a space after certain keywords
+    "linebreak-style": ["error", "unix"], // disallow mixed 'LF' and 'CRLF' as linebreaks
+    "lines-around-comment": "error", // enforce empty lines around comments
+    "max-depth": "off", // specify the maximum depth that blocks can be nested
+    "max-len": "off", // specify the maximum length of a line in your program
+    "max-nested-callbacks": ["error", 3], // specify the maximum depth callbacks can be nested
+    "max-params": ["warn", {max:5}], // limits the number of parameters that can be used in the function declaration.
+    "max-statements": ["warn", {max:15}], // specify the maximum number of statement allowed in a function
+    "new-cap": ["error", { "capIsNew": false }], // require a capital letter for constructors
+    "new-parens": "error", // disallow the omission of parentheses when invoking a constructor with no arguments
+    "newline-after-var": "off", // require or disallow an empty newline after variable declarations
+    "no-array-constructor": "warn", // disallow use of the Array constructor
+    "no-bitwise": "off", // disallow use of bitwise operators
+    "no-continue": "off", // disallow use of the continue statement
+    "no-inline-comments": "off", // disallow comments inline after code
+    "no-lonely-if": "off", // disallow if as the only statement in an else block
+    "no-mixed-spaces-and-tabs": "error", // disallow mixed spaces and tabs for indentation
+    "no-multiple-empty-lines": ["warn", { "max": 3 }], // disallow multiple empty lines
+    "no-negated-condition": "off", // disallow negated conditions
+    "no-nested-ternary": "error", // disallow nested ternary expressions
+    "no-new-object": "warn", // disallow the use of the Object constructor
+    "no-plusplus": "warn", // disallow use of unary operators, ++ and --
+    "no-restricted-syntax": "off", // disallow use of certain syntax in code
+    "no-spaced-func": "off", // disallow space between function identifier and application
+    "no-ternary": "off", // disallow the use of ternary operators
+    "no-trailing-spaces": "error", // disallow trailing whitespace at the end of lines
+    "no-underscore-dangle": "off", // disallow dangling underscores in identifiers
+    "no-unneeded-ternary": "error", // disallow the use of ternary operators when a simpler alternative exists
+    "no-useless-escape": "off",
+    "object-curly-spacing": ["error", "never"], // require or disallow padding inside curly braces
+    "one-var": "off", // require or disallow one variable declaration per function
+    "operator-assignment": "off", // require assignment operator shorthand where possible or prohibit it entirely
+    "operator-linebreak": "off", // enforce operators to be placed before or after line breaks
+    "padded-blocks": "off", // enforce padding within blocks
+    "quote-props": "off", // require quotes around object literal property names
+    "quotes": ["error", "double"], // specify whether backticks, double or single quotes should be used
+    "require-jsdoc": "off", // Require JSDoc comment
+    "semi": ["error", "never"], // require or disallow use of semicolons instead of ASI
+    "semi-spacing": "off", // enforce spacing before and after semicolons
+    "sort-vars": "error", // sort variables within the same declaration block
+    "sort-keys": ["off", "asc", {"caseSensitive": true, "natural": false}],
+    "space-before-blocks": "error", // space-before-blocks
     "space-before-function-paren": [
       "error",
       {
@@ -184,43 +193,43 @@ module.exports = {
         "asyncArrow": "always"
       }
     ], // require or disallow a space before function opening parenthesis
-    "space-before-keywords": 0, // require a space before certain keywords
-    "space-in-parens": [2, "never"], // require or disallow spaces inside parentheses
-    "space-infix-ops": 2, // require spaces around operators
-    "space-return-throw-case": 0, // require a space after return, throw, and case
-    "space-unary-ops": 0, // require or disallow spaces before/after unary operators
-    "spaced-comment": 2, // require or disallow a space immediately following the // or /* in a comment
-    "wrap-regex": 0, // require regex literals to be wrapped in parentheses
+    "space-before-keywords": "off", // require a space before certain keywords
+    "space-in-parens": ["error", "never"], // require or disallow spaces inside parentheses
+    "space-infix-ops": "error", // require spaces around operators
+    "space-return-throw-case": "off", // require a space after return, throw, and case
+    "space-unary-ops": "off", // require or disallow spaces before/after unary operators
+    "spaced-comment": "error", // require or disallow a space immediately following the // or /* in a comment
+    "wrap-regex": "off", // require regex literals to be wrapped in parentheses
 
     // ECMAScript 6
-    "arrow-body-style": 0, // require braces in arrow function body
-    "arrow-parens": 0, // require parens in arrow function arguments
-    "arrow-spacing": 0, // require space before/after arrow function's arrow
-    "constructor-super": 2, // verify calls of super() in constructors
-    "generator-star-spacing": 0, // enforce spacing around the * in generator functions
-    "no-arrow-condition": 0, // disallow arrow functions where a condition is expected
-    "no-class-assign": 0, // disallow modifying variables of class declarations
-    "no-const-assign": 2, // disallow modifying variables that are declared using const
-    "no-dupe-class-members": 0, // disallow duplicate name in class members
-    "no-this-before-super": 2, // disallow use of this/super before calling super() in constructors.
-    "no-var": 2, // require let or const instead of var
-    "object-shorthand": 2, // require method and property shorthand syntax for object literals
-    "prefer-arrow-callback": 0, // suggest using arrow functions as callbacks
-    "prefer-const": 2, // uggest using const declaration for variables that are never modified after declared
-    "prefer-reflect": 0, // suggest using Reflect methods where applicable
-    "prefer-spread": 0, // suggest using the spread operator instead of .apply().
-    "prefer-template": 0, // suggest using template literals instead of strings concatenation
-    "require-yield": 0, // disallow generator functions that do not have yield
+    "arrow-body-style": "off", // require braces in arrow function body
+    "arrow-parens": "off", // require parens in arrow function arguments
+    "arrow-spacing": "off", // require space before/after arrow function's arrow
+    "constructor-super": "error", // verify calls of super() in constructors
+    "generator-star-spacing": "off", // enforce spacing around the * in generator functions
+    "no-arrow-condition": "off", // disallow arrow functions where a condition is expected
+    "no-class-assign": "off", // disallow modifying variables of class declarations
+    "no-const-assign": "error", // disallow modifying variables that are declared using const
+    "no-dupe-class-members": "off", // disallow duplicate name in class members
+    "no-this-before-super": "error", // disallow use of this/super before calling super() in constructors.
+    "no-var": "error", // require let or const instead of var
+    "object-shorthand": "error", // require method and property shorthand syntax for object literals
+    "prefer-arrow-callback": "off", // suggest using arrow functions as callbacks
+    "prefer-const": "error", // uggest using const declaration for variables that are never modified after declared
+    "prefer-reflect": "off", // suggest using Reflect methods where applicable
+    "prefer-spread": "off", // suggest using the spread operator instead of .apply().
+    "prefer-template": "off", // suggest using template literals instead of strings concatenation
+    "require-yield": "off", // disallow generator functions that do not have yield
 
     // Variables
-    "no-delete-var": 2, // disallow deleting variables
-    "no-label-var": 2, // disallow labels that share a name with a variable
-    "no-global-assign": 2, // Disallow assignment to native objects or read-only global variables
-    "no-restricted-globals": [2, "event", "fdescribe"], // disallow specified global variables
-    "no-shadow": 2, //	disallow variable declarations from shadowing variables declared in the outer scope
-    "no-shadow-restricted-names": 2, // disallow identifiers from shadowing restricted names
-    "no-undef": 2, // disallow the use of undeclared variables unless mentioned in `/*global */` comments
-    "no-undef-init": 2, // disallow initializing variables to `undefined`
-    "no-use-before-define": 2,//disallow the use of variables before they are defined
+    "no-delete-var": "error", // disallow deleting variables
+    "no-label-var": "error", // disallow labels that share a name with a variable
+    "no-global-assign": "error", // Disallow assignment to native objects or read-only global variables
+    "no-restricted-globals": ["error", "event", "fdescribe"], // disallow specified global variables
+    "no-shadow": "error", //	disallow variable declarations from shadowing variables declared in the outer scope
+    "no-shadow-restricted-names": "error", // disallow identifiers from shadowing restricted names
+    "no-undef": "error", // disallow the use of undeclared variables unless mentioned in `/*global */` comments
+    "no-undef-init": "error", // disallow initializing variables to `undefined`
+    "no-use-before-define": "error",//disallow the use of variables before they are defined
   }
 }

--- a/index.js
+++ b/index.js
@@ -33,7 +33,7 @@ module.exports = {
     // Possible Errors
     "comma-dangle": ["error", "always-multiline"], // disallow or enforce trailing commas
     "no-cond-assign": "error", // disallow assignment in conditional expressions
-    "no-console": "off", // disallow use of console in the node environment
+    "no-console": "error", // disallow use of console in the node environment
     "no-constant-condition": "error", // disallow use of constant expressions in conditions
     "no-control-regex": "error", // disallow control characters in regular expressions
     "no-debugger": "warn", // disallow use of debugger
@@ -230,6 +230,22 @@ module.exports = {
     "no-shadow-restricted-names": "error", // disallow identifiers from shadowing restricted names
     "no-undef": "error", // disallow the use of undeclared variables unless mentioned in `/*global */` comments
     "no-undef-init": "error", // disallow initializing variables to `undefined`
-    "no-use-before-define": "error",//disallow the use of variables before they are defined
-  }
+
+    // Promise
+    "promise/no-nesting": "off",
+  },
+  "overrides": [
+    {
+      "files": ["src/**/__tests__/*.js", "test/**/*"],
+      "rules": {
+        // Mocha
+        "mocha/no-mocha-arrows": "off",
+        "mocha/no-top-level-hooks": "off",
+        "mocha/no-hooks-for-single-case": "off",
+        "mocha/no-exclusive-tests": "error",
+
+        "security-node/detect-crlf": "off"
+      }
+    }
+  ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,19 +9,27 @@
       "version": "9.0.0",
       "license": "MIT",
       "peerDependencies": {
-        "eslint": "^8.x",
-        "eslint-plugin-fp": "^2.x",
-        "eslint-plugin-json": "^3.x",
-        "eslint-plugin-mocha": "^10.x",
-        "eslint-plugin-promise": "^6.x",
-        "eslint-plugin-react-hooks": "^4.x",
-        "eslint-plugin-security-node": "^1.x"
+        "eslint": "^8",
+        "eslint-config-prettier": "^8",
+        "eslint-plugin-fp": "^2",
+        "eslint-plugin-json": "^3",
+        "eslint-plugin-mocha": "^10",
+        "eslint-plugin-prettier": "^4",
+        "eslint-plugin-promise": "^6",
+        "eslint-plugin-react-hooks": "^4",
+        "eslint-plugin-security-node": "^1"
       },
       "peerDependenciesMeta": {
+        "eslint-config-prettier": {
+          "optional": true
+        },
         "eslint-plugin-fp": {
           "optional": true
         },
         "eslint-plugin-json": {
+          "optional": true
+        },
+        "eslint-plugin-prettier": {
           "optional": true
         },
         "eslint-plugin-react-hooks": {

--- a/package.json
+++ b/package.json
@@ -22,19 +22,27 @@
   },
   "homepage": "https://github.com/momentumft/eslint-config-momentumft#readme",
   "peerDependencies": {
-    "eslint": "^8.x",
-    "eslint-plugin-fp": "^2.x",
-    "eslint-plugin-json": "^3.x",
-    "eslint-plugin-mocha": "^10.x",
-    "eslint-plugin-promise": "^6.x",
-    "eslint-plugin-react-hooks": "^4.x",
-    "eslint-plugin-security-node": "^1.x"
+    "eslint-config-prettier": "^8",
+    "eslint-plugin-fp": "^2",
+    "eslint-plugin-json": "^3",
+    "eslint-plugin-mocha": "^10",
+    "eslint-plugin-prettier": "^4",
+    "eslint-plugin-promise": "^6",
+    "eslint-plugin-react-hooks": "^4",
+    "eslint-plugin-security-node": "^1",
+    "eslint": "^8"
   },
   "peerDependenciesMeta": {
+    "eslint-config-prettier": {
+      "optional": true
+    },
     "eslint-plugin-fp": {
       "optional": true
     },
     "eslint-plugin-json": {
+      "optional": true
+    },
+    "eslint-plugin-prettier": {
       "optional": true
     },
     "eslint-plugin-react-hooks": {

--- a/prettier.js
+++ b/prettier.js
@@ -1,0 +1,8 @@
+module.exports = {
+  "extends": [
+    "plugin:prettier/recommended"
+  ],
+  "plugins": [
+    "prettier"
+  ]
+}

--- a/react.js
+++ b/react.js
@@ -14,46 +14,46 @@ module.exports = {
   // Plugins
   // React
   rules: {
-    "react/display-name": 0, // Prevent missing displayName in a React component definition
-    "react/forbid-prop-types": 0, // Forbid certain propTypes
-    "react/jsx-boolean-value": 0, // Enforce boolean attributes notation in JSX (fixable)
-    "react/jsx-closing-bracket-location": 0, // Validate closing bracket location in JSX
-    "react/jsx-curly-spacing": [2, "never"], // Enforce or disallow spaces inside of curly braces in JSX attributes (fixable)
-    "react/jsx-equals-spacing": 0, // Enforce or disallow spaces around equal signs in JSX attributes
-    "react/jsx-handler-names": 0, // Enforce event handler naming conventions in JSX
-    "react/jsx-indent": 0, // Validate JSX indentation
-    "react/jsx-indent-props": 0, // Validate props indentation in JSX
-    "react/jsx-key": 0, // Validate JSX has key prop when in array or iterator
-    "react/jsx-max-props-per-line": 0, // Limit maximum of props on a single line in JSX
-    "react/jsx-no-bind": 0, // Prevent usage of .bind() and arrow functions in JSX props
-    "react/jsx-no-duplicate-props": 0, // Prevent duplicate props in JSX
-    "react/jsx-no-literals": 0, // Prevent usage of unwrapped JSX strings
-    "react/jsx-no-undef": 2, // Disallow undeclared variables in JSX
-    "react/jsx-pascal-case": 0, // Enforce PascalCase for user-defined JSX components
-    "react/jsx-quotes": 0, // Enforce quote style for JSX attributes
-    "react/jsx-sort-prop-types": 0, // Enforce propTypes declarations alphabetical sorting
-    "react/jsx-sort-props": 0, // Enforce props alphabetical sorting
-    "react/jsx-space-before-closing": 0, // Validate spacing before closing bracket in JSX (fixable)
-    "react/jsx-uses-react": 2, // Prevent React to be incorrectly marked as unused
-    "react/jsx-uses-vars": 2, // Prevent variables used in JSX to be incorrectly marked as unused
-    "react/no-danger": 0, // Prevent usage of dangerous JSX properties
-    "react/no-deprecated": 0, // Prevent usage of deprecated methods
-    "react/no-did-mount-set-state": 2, // Prevent usage of setState in componentDidMount
-    "react/no-did-update-set-state": 2, // Prevent usage of setState in componentDidUpdate
-    "react/no-direct-mutation-state": 0, // Prevent direct mutation of this.state
-    "react/no-is-mounted": 0, // Prevent usage of isMounted
-    "react/no-multi-comp": [2, { ignoreStateless: true }], // Prevent multiple component definition per file
-    "react/no-set-state": 0, // Prevent usage of setState
-    "react/no-string-refs": 0, // Prevent using string references in ref attribute.
-    "react/no-unknown-property": 2, // Prevent usage of unknown DOM property (fixable)
-    "react/prefer-es6-class": 0, // Enforce ES5 or ES6 class for React Components
-    "react/prop-types": 2, // Prevent missing props validation in a React component definition
-    "react/react-in-jsx-scope": 2, // Prevent missing React when using JSX
-    "react/require-extension": 0, // Restrict file extensions that may be required
-    "react/self-closing-comp": 2, // Prevent extra closing tags for components without children
-    "react/sort-comp": 0, // Enforce component methods order
-    "react/jsx-wrap-multilines": 2, // Prevent missing parentheses around multilines JSX (fixable)
-    "react/no-children-prop": 0,
+    "react/display-name": "off", // Prevent missing displayName in a React component definition
+    "react/forbid-prop-types": "off", // Forbid certain propTypes
+    "react/jsx-boolean-value": "off", // Enforce boolean attributes notation in JSX (fixable)
+    "react/jsx-closing-bracket-location": "off", // Validate closing bracket location in JSX
+    "react/jsx-curly-spacing": ["error", "never"], // Enforce or disallow spaces inside of curly braces in JSX attributes (fixable)
+    "react/jsx-equals-spacing": "off", // Enforce or disallow spaces around equal signs in JSX attributes
+    "react/jsx-handler-names": "off", // Enforce event handler naming conventions in JSX
+    "react/jsx-indent": "off", // Validate JSX indentation
+    "react/jsx-indent-props": "off", // Validate props indentation in JSX
+    "react/jsx-key": "off", // Validate JSX has key prop when in array or iterator
+    "react/jsx-max-props-per-line": "off", // Limit maximum of props on a single line in JSX
+    "react/jsx-no-bind": "off", // Prevent usage of .bind() and arrow functions in JSX props
+    "react/jsx-no-duplicate-props": "off", // Prevent duplicate props in JSX
+    "react/jsx-no-literals": "off", // Prevent usage of unwrapped JSX strings
+    "react/jsx-no-undef": "error", // Disallow undeclared variables in JSX
+    "react/jsx-pascal-case": "off", // Enforce PascalCase for user-defined JSX components
+    "react/jsx-quotes": "off", // Enforce quote style for JSX attributes
+    "react/jsx-sort-prop-types": "off", // Enforce propTypes declarations alphabetical sorting
+    "react/jsx-sort-props": "off", // Enforce props alphabetical sorting
+    "react/jsx-space-before-closing": "off", // Validate spacing before closing bracket in JSX (fixable)
+    "react/jsx-uses-react": "error", // Prevent React to be incorrectly marked as unused
+    "react/jsx-uses-vars": "error", // Prevent variables used in JSX to be incorrectly marked as unused
+    "react/no-danger": "off", // Prevent usage of dangerous JSX properties
+    "react/no-deprecated": "off", // Prevent usage of deprecated methods
+    "react/no-did-mount-set-state": "error", // Prevent usage of setState in componentDidMount
+    "react/no-did-update-set-state": "error", // Prevent usage of setState in componentDidUpdate
+    "react/no-direct-mutation-state": "off", // Prevent direct mutation of this.state
+    "react/no-is-mounted": "off", // Prevent usage of isMounted
+    "react/no-multi-comp": ["error", { ignoreStateless: true }], // Prevent multiple component definition per file
+    "react/no-set-state": "off", // Prevent usage of setState
+    "react/no-string-refs": "off", // Prevent using string references in ref attribute.
+    "react/no-unknown-property": "error", // Prevent usage of unknown DOM property (fixable)
+    "react/prefer-es6-class": "off", // Enforce ES5 or ES6 class for React Components
+    "react/prop-types": "error", // Prevent missing props validation in a React component definition
+    "react/react-in-jsx-scope": "error", // Prevent missing React when using JSX
+    "react/require-extension": "off", // Restrict file extensions that may be required
+    "react/self-closing-comp": "error", // Prevent extra closing tags for components without children
+    "react/sort-comp": "off", // Enforce component methods order
+    "react/jsx-wrap-multilines": "error", // Prevent missing parentheses around multilines JSX (fixable)
+    "react/no-children-prop": "off",
     "react-hooks/rules-of-hooks": "error",
     "react-hooks/exhaustive-deps": "warn"
   }


### PR DESCRIPTION
- Change rule severities from numbers to strings
- Error on console logs
- Error on exclusive mocha tests
- Disable annoying rules (let me know if you have any other suggestions)
- Add prettier config, use like:

```
"extends": [
    "@mft/eslint-config-momentumft",
    "@mft/eslint-config-momentumft/prettier"
  ],
```